### PR TITLE
020, 022, 024 subfields a and z as indentifierQueries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@natlibfi/melinda-commons",
-	"version": "6.0.0",
+	"version": "7.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -3078,7 +3078,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -3099,12 +3100,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -3119,17 +3122,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -3246,7 +3252,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -3258,6 +3265,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -3272,6 +3280,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -3279,12 +3288,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -3303,6 +3314,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -3383,7 +3395,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -3395,6 +3408,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -3480,7 +3494,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -3516,6 +3531,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -3535,6 +3551,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -3578,12 +3595,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/src/record-matching/bib/generate-query-list.js
+++ b/src/record-matching/bib/generate-query-list.js
@@ -35,12 +35,10 @@ export function generateIdentifierQueries(record) {
 			.reduce((acc, field) => {
 				const codes = ['a', 'z'];
 				field.subfields
-					.filter(sub => {
+					.forEach(sub => {
 						if (codes.includes(sub.code) && !acc.includes(sub.value)) {
 							acc.push(sub.value);
 						}
-
-						return null;
 					});
 
 				return acc;

--- a/src/record-matching/bib/generate-query-list.js
+++ b/src/record-matching/bib/generate-query-list.js
@@ -33,15 +33,15 @@ export function generateIdentifierQueries(record) {
 	function getStandardIdentifiers() {
 		return record.get(/^020|022|024$/)
 			.reduce((acc, field) => {
-				for (const sfcode of ['a', 'z']) {
-					const subfield = field.subfields.find(sf => sf.code === sfcode);
-					if (subfield) {
-						const id = subfield.value;
-						if (id in acc === false) {
-							acc = acc.concat(id);
+				const codes = ['a', 'z'];
+				field.subfields
+					.filter(sub => {
+						if (codes.includes(sub.code) && !acc.includes(sub.value)) {
+							acc.push(sub.value);
 						}
-					}
-				}
+
+						return null;
+					});
 
 				return acc;
 			}, []);

--- a/src/record-matching/bib/generate-query-list.js
+++ b/src/record-matching/bib/generate-query-list.js
@@ -33,11 +33,14 @@ export function generateIdentifierQueries(record) {
 	function getStandardIdentifiers() {
 		return record.get(/^020|022|024$/)
 			.reduce((acc, field) => {
-				const subfield = field.subfields.find(sf => sf.code === 'a');
-
-				if (subfield) {
-					const id = subfield.value;
-					return id in acc ? acc : acc.concat(id);
+				for (const sfcode of ['a', 'z']) {
+					const subfield = field.subfields.find(sf => sf.code === sfcode);
+					if (subfield) {
+						const id = subfield.value;
+						if (id in acc === false) {
+							acc = acc.concat(id);
+						}
+					}
 				}
 
 				return acc;

--- a/src/record-matching/bib/generate-query-list.spec.js
+++ b/src/record-matching/bib/generate-query-list.spec.js
@@ -39,10 +39,12 @@ const FIXTURES_PATH = path.join(__dirname, '../../../test-fixtures/record-matchi
 const record1 = fs.readFileSync(path.join(FIXTURES_PATH, 'record1.json'), 'utf8');
 const record2 = fs.readFileSync(path.join(FIXTURES_PATH, 'record2.json'), 'utf8');
 const record3 = fs.readFileSync(path.join(FIXTURES_PATH, 'record3.json'), 'utf8');
+const record4 = fs.readFileSync(path.join(FIXTURES_PATH, 'record4.json'), 'utf8');
 
 const queryList1 = fs.readFileSync(path.join(FIXTURES_PATH, 'queryList1.json'), 'utf8');
 const queryList2 = fs.readFileSync(path.join(FIXTURES_PATH, 'queryList2.json'), 'utf8');
 const queryList3 = fs.readFileSync(path.join(FIXTURES_PATH, 'queryList3.json'), 'utf8');
+const queryList4 = fs.readFileSync(path.join(FIXTURES_PATH, 'queryList4.json'), 'utf8');
 
 describe('record-matching/bib/generate-query-list', () => {
 	describe('#generateIdentifierQueries', () => {
@@ -58,6 +60,13 @@ describe('record-matching/bib/generate-query-list', () => {
 			const queryList = generateIdentifierQueries(record);
 
 			expect(queryList).to.eql(JSON.parse(queryList2));
+		});
+
+		it('Should generate a list of multible identifiers from subfield a and z', () => {
+			const record = new MarcRecord(JSON.parse(record4));
+			const queryList = generateIdentifierQueries(record);
+
+			expect(queryList).to.eql(JSON.parse(queryList4));
 		});
 	});
 

--- a/test-fixtures/record-matching/bib/generate-query-list/queryList4.json
+++ b/test-fixtures/record-matching/bib/generate-query-list/queryList4.json
@@ -1,0 +1,6 @@
+[
+    "dc.identifier=0-471-86529-X",
+    "dc.identifier=0-471-86529-Y",
+    "dc.identifier=0-471-86529-Z",
+    "dc.identifier=0-471-86529-A"
+]

--- a/test-fixtures/record-matching/bib/generate-query-list/record4.json
+++ b/test-fixtures/record-matching/bib/generate-query-list/record4.json
@@ -1,0 +1,395 @@
+{
+  "leader": "01121cam a22003254i 4500",
+  "fields": [
+    {
+      "tag": "001",
+      "value": "000095000"
+    },
+    {
+      "tag": "003",
+      "value": "FCC"
+    },
+    {
+      "tag": "005",
+      "value": "20141222102655.0"
+    },
+    {
+      "tag": "008",
+      "value": "940518s1982    xxu|||||||||||||||||eng||"
+    },
+    {
+      "tag": "FMT",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "K",
+          "value": ""
+        }
+      ]
+    },
+    {
+      "tag": "020",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "0-471-86529-X"
+        },
+        {
+          "code": "q",
+          "value": "inbunden"
+        },
+        {
+          "code": "z",
+          "value": "0-471-86529-Y"
+        }
+      ]
+    },
+    {
+      "tag": "024",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "0-471-86529-Z"
+        },
+        {
+          "code": "q",
+          "value": "inbunden"
+        },
+        {
+          "code": "z",
+          "value": "0-471-86529-A"
+        }
+      ]
+    },
+    {
+      "tag": "035",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "(FI-MELINDA)000095000"
+        }
+      ]
+    },
+    {
+      "tag": "041",
+      "ind1": "0",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "eng"
+        }
+      ]
+    },
+    {
+      "tag": "080",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "65.012.4"
+        }
+      ]
+    },
+    {
+      "tag": "100",
+      "ind1": "1",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Elfrey, Priscilla."
+        }
+      ]
+    },
+    {
+      "tag": "245",
+      "ind1": "1",
+      "ind2": "4",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "The hidden agenda :"
+        },
+        {
+          "code": "b",
+          "value": "recognizing what really matters at work /"
+        },
+        {
+          "code": "c",
+          "value": "Priscilla Elfrey."
+        }
+      ]
+    },
+    {
+      "tag": "260",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "New York :"
+        },
+        {
+          "code": "b",
+          "value": "Wiley,"
+        },
+        {
+          "code": "c",
+          "value": "1982."
+        }
+      ]
+    },
+    {
+      "tag": "300",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "xiii, 208 s"
+        }
+      ]
+    },
+    {
+      "tag": "336",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "teksti"
+        },
+        {
+          "code": "b",
+          "value": "txt"
+        },
+        {
+          "code": "2",
+          "value": "rdacontent"
+        }
+      ]
+    },
+    {
+      "tag": "337",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "käytettävissä ilman laitetta"
+        },
+        {
+          "code": "b",
+          "value": "n"
+        },
+        {
+          "code": "2",
+          "value": "rdamedia"
+        }
+      ]
+    },
+    {
+      "tag": "338",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "nide"
+        },
+        {
+          "code": "b",
+          "value": "nc"
+        },
+        {
+          "code": "2",
+          "value": "rdacarrier"
+        }
+      ]
+    },
+    {
+      "tag": "490",
+      "ind1": "1",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Wiley management series on problem solving, decision making, and strategic thinking"
+        }
+      ]
+    },
+    {
+      "tag": "830",
+      "ind1": " ",
+      "ind2": "0",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "Wiley management series on problem solving, decision making, and strategic thinking."
+        }
+      ]
+    },
+    {
+      "tag": "SID",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "c",
+          "value": "209565"
+        },
+        {
+          "code": "b",
+          "value": "alma"
+        }
+      ]
+    },
+    {
+      "tag": "CAT",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "CONV-ISBD"
+        },
+        {
+          "code": "b",
+          "value": ""
+        },
+        {
+          "code": "c",
+          "value": "20120401"
+        },
+        {
+          "code": "l",
+          "value": "FIN01"
+        },
+        {
+          "code": "h",
+          "value": "2034"
+        }
+      ]
+    },
+    {
+      "tag": "CAT",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "LOAD-FIX"
+        },
+        {
+          "code": "b",
+          "value": "30"
+        },
+        {
+          "code": "c",
+          "value": "20141222"
+        },
+        {
+          "code": "l",
+          "value": "FIN01"
+        },
+        {
+          "code": "h",
+          "value": "1026"
+        }
+      ]
+    },
+    {
+      "tag": "CAT",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "LOAD-FIX"
+        },
+        {
+          "code": "b",
+          "value": "30"
+        },
+        {
+          "code": "c",
+          "value": "20141222"
+        },
+        {
+          "code": "l",
+          "value": "FIN01"
+        },
+        {
+          "code": "h",
+          "value": "1026"
+        }
+      ]
+    },
+    {
+      "tag": "CAT",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "CONV-RDA"
+        },
+        {
+          "code": "b",
+          "value": ""
+        },
+        {
+          "code": "c",
+          "value": "20160319"
+        },
+        {
+          "code": "l",
+          "value": "FIN01"
+        },
+        {
+          "code": "h",
+          "value": "0813"
+        }
+      ]
+    },
+    {
+      "tag": "CAT",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "c",
+          "value": "20160324"
+        },
+        {
+          "code": "l",
+          "value": "FIN01"
+        },
+        {
+          "code": "h",
+          "value": "1657"
+        }
+      ]
+    },
+    {
+      "tag": "LOW",
+      "ind1": " ",
+      "ind2": " ",
+      "subfields": [
+        {
+          "code": "a",
+          "value": "ALMA"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
`generate-query-lit.js/getStandardIdentifiers()` now picks values from both subfields a and z in fields 020, 022 and 024

And made tests for it